### PR TITLE
Format output with gotemplates

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -40,7 +40,7 @@ func formatOutput(jsonBytes []byte, format string) ([]byte, error) {
 }
 
 //OutputResult writes the body of an http.Response to stdout
-func OutputResult(resp *http.Response, rawJSON bool, format string, stdout io.Writer) error {
+func OutputResult(resp *http.Response, rawOutput bool, format string, stdout io.Writer) error {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func OutputResult(resp *http.Response, rawJSON bool, format string, stdout io.Wr
 			return err
 		}
 	} else {
-		if !rawJSON {
+		if !rawOutput {
 			body, err = prettyPrintJSON(body)
 			if err != nil {
 				return err

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,12 +1,14 @@
 package internal
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"text/template"
 )
 
 func prettyPrintJSON(jsonBytes []byte) ([]byte, error) {
@@ -19,8 +21,26 @@ func prettyPrintJSON(jsonBytes []byte) ([]byte, error) {
 	return out, errors.Wrap(err, "failed marshalling json")
 }
 
+func formatOutput(jsonBytes []byte, format string) ([]byte, error) {
+	var it interface{}
+	err := json.Unmarshal(jsonBytes, &it)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed unmarshalling json")
+	}
+	tmpl, err := template.New("").Parse(string(format))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed parsing format template")
+	}
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, it)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed executing template")
+	}
+	return buf.Bytes(), err
+}
+
 //OutputResult writes the body of an http.Response to stdout
-func OutputResult(resp *http.Response, rawJSON bool, stdout io.Writer) error {
+func OutputResult(resp *http.Response, rawJSON bool, format string, stdout io.Writer) error {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
@@ -29,10 +49,17 @@ func OutputResult(resp *http.Response, rawJSON bool, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if !rawJSON {
-		body, err = prettyPrintJSON(body)
+	if format != "" {
+		body, err = formatOutput(body, format)
 		if err != nil {
 			return err
+		}
+	} else {
+		if !rawJSON {
+			body, err = prettyPrintJSON(body)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	_, err = fmt.Fprintln(stdout, string(body))

--- a/internal/util.go
+++ b/internal/util.go
@@ -62,6 +62,6 @@ func OutputResult(resp *http.Response, rawJSON bool, format string, stdout io.Wr
 			}
 		}
 	}
-	_, err = fmt.Fprintln(stdout, string(body))
+	_, err = fmt.Fprint(stdout, string(body))
 	return err
 }

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -1,8 +1,13 @@
 package internal
 
 import (
-	"github.com/stretchr/testify/assert"
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_prettyPrintJSON(t *testing.T) {
@@ -36,6 +41,87 @@ func Test_prettyPrintJSON(t *testing.T) {
 			got, err := prettyPrintJSON([]byte(test.input))
 			assert.Nil(t, err)
 			assert.Equal(t, test.want, string(got))
+
+		})
+	}
+}
+
+func TestOutputResult(t *testing.T) {
+	type args struct {
+		respBody string
+		rawJSON  bool
+		format   string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantStdout string
+		wantErr    bool
+	}{
+		{
+			name: "raw text",
+			args: args{
+				respBody: "hello",
+				rawJSON:  true,
+				format:   "",
+			},
+			wantStdout: "hello",
+			wantErr:    false,
+		},
+		{
+			name: "raw json",
+			args: args{
+				respBody: `{"hello": "hi"}`,
+				rawJSON:  true,
+				format:   "",
+			},
+			wantStdout: `{"hello": "hi"}`,
+			wantErr:    false,
+		},
+		{
+			name: "pretty json",
+			args: args{
+				respBody: `{"hello": "hi"}`,
+				rawJSON:  false,
+				format:   "",
+			},
+			wantStdout: `{
+  "hello": "hi"
+}`,
+			wantErr: false,
+		},
+		{
+			name: "invalid json",
+			args: args{
+				respBody: `{"hello": "hi"`,
+				rawJSON:  false,
+				format:   "",
+			},
+			wantStdout: "",
+			wantErr:    true,
+		},
+		{
+			name: "format",
+			args: args{
+				respBody: `{"hello": "hi"}`,
+				rawJSON:  false,
+				format:   "hello {{.hello}}",
+			},
+			wantStdout: "hello hi",
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			resp := &http.Response{
+				Body: ioutil.NopCloser(strings.NewReader(tt.args.respBody)),
+			}
+			if err := OutputResult(resp, tt.args.rawJSON, tt.args.format, stdout); (err != nil) != tt.wantErr {
+				t.Errorf("OutputResult() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.wantStdout, stdout.String())
 
 		})
 	}

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -48,9 +48,9 @@ func Test_prettyPrintJSON(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		respBody string
-		rawJSON  bool
-		format   string
+		respBody  string
+		rawOutput bool
+		format    string
 	}
 	tests := []struct {
 		name       string
@@ -61,9 +61,9 @@ func TestOutputResult(t *testing.T) {
 		{
 			name: "raw text",
 			args: args{
-				respBody: "hello",
-				rawJSON:  true,
-				format:   "",
+				respBody:  "hello",
+				rawOutput: true,
+				format:    "",
 			},
 			wantStdout: "hello",
 			wantErr:    false,
@@ -71,9 +71,9 @@ func TestOutputResult(t *testing.T) {
 		{
 			name: "raw json",
 			args: args{
-				respBody: `{"hello": "hi"}`,
-				rawJSON:  true,
-				format:   "",
+				respBody:  `{"hello": "hi"}`,
+				rawOutput: true,
+				format:    "",
 			},
 			wantStdout: `{"hello": "hi"}`,
 			wantErr:    false,
@@ -81,9 +81,9 @@ func TestOutputResult(t *testing.T) {
 		{
 			name: "pretty json",
 			args: args{
-				respBody: `{"hello": "hi"}`,
-				rawJSON:  false,
-				format:   "",
+				respBody:  `{"hello": "hi"}`,
+				rawOutput: false,
+				format:    "",
 			},
 			wantStdout: `{
   "hello": "hi"
@@ -93,9 +93,9 @@ func TestOutputResult(t *testing.T) {
 		{
 			name: "invalid json",
 			args: args{
-				respBody: `{"hello": "hi"`,
-				rawJSON:  false,
-				format:   "",
+				respBody:  `{"hello": "hi"`,
+				rawOutput: false,
+				format:    "",
 			},
 			wantStdout: "",
 			wantErr:    true,
@@ -103,9 +103,9 @@ func TestOutputResult(t *testing.T) {
 		{
 			name: "format",
 			args: args{
-				respBody: `{"hello": "hi"}`,
-				rawJSON:  false,
-				format:   "hello {{.hello}}",
+				respBody:  `{"hello": "hi"}`,
+				rawOutput: false,
+				format:    "hello {{.hello}}",
 			},
 			wantStdout: "hello hi",
 			wantErr:    false,
@@ -117,7 +117,7 @@ func TestOutputResult(t *testing.T) {
 			resp := &http.Response{
 				Body: ioutil.NopCloser(strings.NewReader(tt.args.respBody)),
 			}
-			if err := OutputResult(resp, tt.args.rawJSON, tt.args.format, stdout); (err != nil) != tt.wantErr {
+			if err := OutputResult(resp, tt.args.rawOutput, tt.args.format, stdout); (err != nil) != tt.wantErr {
 				t.Errorf("OutputResult() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestPrettyPrintJson(t *testing.T) {
+func Test_prettyPrintJSON(t *testing.T) {
 	for _, test := range []struct {
 		name  string
 		input string

--- a/services/artisanally_handcrafted_code.go
+++ b/services/artisanally_handcrafted_code.go
@@ -24,6 +24,7 @@ type baseCmd struct {
 	Token         string `env:"GITHUB_TOKEN" required:""`
 	APIBaseURL    string `env:"GITHUB_API_BASE_URL" default:"https://api.github.com"`
 	RawOutput     bool   `help:"don't format json output."`
+	Format        string `help:"format output with a go template"`
 }
 
 func (c *baseCmd) isValueSet(valueName string) bool {
@@ -120,5 +121,5 @@ func (c *baseCmd) doRequest(method string) error {
 		return err
 	}
 
-	return internal.OutputResult(resp, c.RawOutput, stdout)
+	return internal.OutputResult(resp, c.RawOutput, c.Format, stdout)
 }


### PR DESCRIPTION
closes #15 

Adds --format output that uses a go template to format response output.

For example, if you just want the title of an issue surrounded by single quotes use:

```shell
bin/go-github-cli issues get --owner go-github-cli --repo go-github-cli --number 15 --format "'{{.title}}'"
'output formatting with go templates'
```
